### PR TITLE
Add error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Base function for creating a MessageHandler to parse and handle consumed message
 
 ### defaultParseAndHandleMessage : ((error:mixed &rArr; Promise&lt;mixed&gt;), MessageContentHandler&lt;JsonValue, mixed&gt;) &rArr; MessageHandler&lt;mixed&gt;
 
-Create a message handler that parses messages in JSON format, and automatically **Acks** upon success or failed message handling (IOW, it drops failed messages).
+Create a message handler that parses messages in JSON format, and automatically **acks** upon success or failed message handling. If an errors occurs during message parsing (e.g. invalid JSON) *or* message handling, the error will be passed to the error handler function (first param), *and the message will still be **acked***.  If you need different error handling ack/nack behavior, use `parseAndHandleMessage`.
 
 ### parseJsonMessage : string &rArr; MessageParser&lt;JsonValue&gt;
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ const consumeConfig = {
   routingKey: 'some-routing-key'
 }
 
-const handleMessage = defaultParseAndHandleMessage((data) => {
+const handleError = async (e) => logError(e)
+
+const handleMessage = defaultParseAndHandleMessage(handleError, (data) => {
   // Content will be the *parsed* message content.
   // Do something with it
   // IMPORTANT: Always return a promise to indicate
@@ -110,28 +112,28 @@ consume(consumeConfig, handleMessage)
 
 ## Types
 
-### type PublishConfig = ExchangeConfig & {routingKey: string}
+### type PublishConfig = `{exchangeName: string, routingKey: string}`
 
 Exchange and routingKey pair for setting up a publisher
 Publishers don't care about queue names
 
-### type ConsumeConfig = PublishConfig & {queueName: string}
+### type ConsumeConfig = PublishConfig & `{queueName: string}`
 
 Exchange, queue, and routingKey tuple for setting up a consumer
 
-### type PublishChannel = Channel<AmqpPublishChannel>
+### type PublishChannel = Channel&lt;AmqpPublishChannel&gt;
 
 A channel to which messages may be published
 
-### type ConsumeChannel = Channel<AmqpConsumeChannel>
+### type ConsumeChannel = Channel&lt;AmqpConsumeChannel&gt;
 
 A channel from which messages may be consumed
 
-### type DuplexChannel = Channel<AmqpDuplexChannel>
+### type DuplexChannel = Channel&lt;AmqpDuplexChannel&gt;
 
 A channel that is both a PublishChannel and a ConsumeChannel
 
-### type Publisher = string &rArr Promise<boolean>
+### type Publisher = string &rArr; Promise&lt;boolean&gt;
 
 Message publishing function type returned by `publishTo`
 
@@ -145,7 +147,7 @@ Create a Channel on a standard AmqpConnection (created with amqplib).  The Chann
 
 Create a Channel on an AmqpManagedConnection (created with amqp-connection-manager).  The Channel may only be used to publish messages.
 
-### consumeFrom : ConsumeChannel &rArr; (ConsumeConfig, MessageHandler) &rArr; Promise<{}>
+### consumeFrom : ConsumeChannel &rArr; (ConsumeConfig, MessageHandler) &rArr; Promise&lt;{}&gt;
 
 Begin consuming messages based on the exchangeName, queueName, and routingKey specified in ConsumeConfig
 
@@ -153,14 +155,14 @@ Begin consuming messages based on the exchangeName, queueName, and routingKey sp
 
 Create a Publisher function which can be used to publish messages to an exchange and routingKey specified in the provided PublishConfig.
 
-### parseAndHandleMessage : MessageParser<C> &rArr; MessageResultHandler<mixed> &rArr; MessageResultHandler<R> &rArr; MessageContentHandler<C, R> &rArr; MessageHandler
+### parseAndHandleMessage : (MessageParser&lt;C&gt;, MessageResultHandler&lt;mixed&gt;, MessageResultHandler&lt;R&gt;, MessageContentHandler&lt;C, R&gt;) &rArr; MessageHandler
 
 Base function for creating a MessageHandler to parse and handle consumed messages.  Most of the time, you'll want to use `defaultParseAndHandleMessage`.  Use this if you need to parse messages from a different format or handle Ack/Nack differently.
 
-### defaultParseAndHandleMessage : MessageContentHandler<JsonValue, mixed> &rArr; MessageHandler<mixed>
+### defaultParseAndHandleMessage : ((error:mixed &rArr; Promise&lt;mixed&gt;), MessageContentHandler&lt;JsonValue, mixed&gt;) &rArr; MessageHandler&lt;mixed&gt;
 
 Create a message handler that parses messages in JSON format, and automatically **Acks** upon success or failed message handling (IOW, it drops failed messages).
 
-### parseJsonMessage : string &rArr; MessageParser<JsonValue>
+### parseJsonMessage : string &rArr; MessageParser&lt;JsonValue&gt;
 
 Helper to create a MessageParser for messages in JSON format.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
+
   "name": "@nowait/amqp",
   "description": "Describe your package",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "engineering@nowait.com",
   "license": "UNLICENSED",
   "main": "build/index.js",

--- a/src/defaultParseAndHandleMessage.js
+++ b/src/defaultParseAndHandleMessage.js
@@ -6,10 +6,19 @@ import type { MessageHandler, MessageResultHandler, MessageContentHandler, JsonV
 import parseAndHandleMessage from './parseAndHandleMessage'
 import parseJsonMessage from './parseJsonMessage'
 
-export default (handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler => {
-  // Generally, errors won't be recovered from
-  // So default behavior here is always to ack, thus dropping failed messages,
-  // rather than nacking, which can lead to infinite retries if not managed carefully
-  const ackOnComplete: MessageResultHandler<mixed> = (ack, nack, message) => ack(message)
-  return parseAndHandleMessage(parseJsonMessage('utf8'), ackOnComplete, ackOnComplete, handleMessage)
+// Generally, errors won't be recovered from
+// So default behavior here is always to ack, thus dropping failed messages,
+// rather than nacking, which can lead to infinite retries if not managed carefully
+export default (handleError: (e:mixed) => Promise<mixed>, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
+  parseAndHandleMessage(parseJsonMessage('utf8'), ackOnError(handleError), ackOnComplete, handleMessage)
+
+const ackOnComplete: MessageResultHandler<mixed> = (ack, nack, message) =>
+  ack(message)
+
+const ackOnError = (handleError) => async (ack, nack, message, e) => {
+  try {
+    await handleError(e)
+  } finally {
+    ack(message)
+  }
 }

--- a/src/parseAndHandleMessage.js
+++ b/src/parseAndHandleMessage.js
@@ -14,16 +14,11 @@ export default function parseAndHandleMessage<C, R> (
   return async (ack, nack, message) => {
     try {
       // Step 1: Triage message
-      // If we can't do this, log error, drop message, continue.
-      // Don't crash
       const parsed = parseMessage(message)
 
       // Step 2: handle parsed message and success/failure
-      return handleMessage(parsed)
-        .then(
-          result => handleSuccess(ack, nack, message, result),
-          error => handleFailure(ack, nack, message, error)
-        )
+      const result = await handleMessage(parsed)
+      return handleSuccess(ack, nack, message, result)
     } catch (e) {
       return handleFailure(ack, nack, message, e)
     }

--- a/test/defaultParseAndHandleMessage-test.js
+++ b/test/defaultParseAndHandleMessage-test.js
@@ -8,12 +8,12 @@ import defaultParseAndHandleMessage from '../src/defaultParseAndHandleMessage'
 describe('defaultParseAndHandleMessage', () => {
   // TODO: This *should nack*, but see comments in parseAndHandleMessage
   // for why it (temporarily) acks instead.
-  it('should ack if message handling fails', () => {
+  it('should call handleError and ack if message handling fails', () => {
     const content = JSON.stringify({ foo: 'bar' })
     const message = { content }
 
     let handleCount = 0
-    const handle = async (data) => {
+    const handleMessage = async (data) => {
       handleCount++
       assert.equal(content, JSON.stringify(data))
       throw new Error()
@@ -29,12 +29,93 @@ describe('defaultParseAndHandleMessage', () => {
       throw new Error('should not nack')
     }
 
-    const parseAndHandle = defaultParseAndHandleMessage(handle)
+    let handleErrorCount = 0
+    const handleError = async (error) => {
+      handleErrorCount++
+      assert(error instanceof Error)
+    }
+
+    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
 
     return parseAndHandle(ack, nack, message)
       .then(() => {
         assert.equal(1, ackCount)
         assert.equal(1, handleCount)
+        assert.equal(1, handleErrorCount)
+      })
+  })
+
+  it('should ack if handleError fails', () => {
+    const content = JSON.stringify({ foo: 'bar' })
+    const message = { content }
+
+    let handleCount = 0
+    const handleMessage = async (data) => {
+      handleCount++
+      assert.equal(content, JSON.stringify(data))
+      throw new Error()
+    }
+
+    let ackCount = 0
+    const ack = msg => {
+      ackCount++
+      assert.strictEqual(message, msg)
+    }
+
+    const nack = () => {
+      throw new Error('should not nack')
+    }
+
+    let handleErrorCount = 0
+    const handleError = async (error) => {
+      handleErrorCount++
+      assert(error instanceof Error)
+      throw new Error()
+    }
+
+    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
+
+    return parseAndHandle(ack, nack, message)
+      .then(assert.ifError, () => {
+        assert.equal(1, ackCount)
+        assert.equal(1, handleCount)
+        assert.equal(1, handleErrorCount)
+      })
+  })
+
+  it('should call handleError and ack if parsing fails', () => {
+    const content = undefined
+    const message = { content }
+
+    let handleCount = 0
+    const handleMessage = async (data) => {
+      handleCount++
+      throw new Error()
+    }
+
+    let ackCount = 0
+    const ack = msg => {
+      ackCount++
+      assert.strictEqual(message, msg)
+    }
+
+    const nack = () => {
+      throw new Error('should not nack')
+    }
+
+    let handleErrorCount = 0
+    const handleError = async (error) => {
+      handleErrorCount++
+      assert(error instanceof Error)
+    }
+
+    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
+
+    return parseAndHandle(ack, nack, message)
+      .then(() => {
+        assert.equal(1, ackCount)
+        assert.equal(0, handleCount)
+        assert.equal(1, handleErrorCount)
       })
   })
 
@@ -43,7 +124,7 @@ describe('defaultParseAndHandleMessage', () => {
     const message = { content }
 
     let handleCount = 0
-    const handle = async (data) => {
+    const handleMessage = async (data) => {
       handleCount++
       assert.equal(content, JSON.stringify(data))
       return data
@@ -59,12 +140,19 @@ describe('defaultParseAndHandleMessage', () => {
       throw new Error('should not nack')
     }
 
-    const parseAndHandle = defaultParseAndHandleMessage(handle)
+    let handleErrorCount = 0
+    const handleError = async (e) => {
+      handleErrorCount++
+      throw e
+    }
+
+    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
 
     return parseAndHandle(ack, nack, message)
       .then(() => {
         assert.equal(1, ackCount)
         assert.equal(1, handleCount)
+        assert.equal(0, handleErrorCount)
       })
   })
 })


### PR DESCRIPTION
Add error handler parameter to `defaultParseAndHandleMessage`, to force callers to think about and deal with parsing or message handling errors.

Note: This is a breaking API change.  Based on [semver](http://semver.org), that *requires* bumping the version to 2.0.0.

Tests, docs, and examples updated.