### PR TITLE
Pass message to error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ build
 .npmrc
 npm-debug.log
 coverage/
+.nyc_output/
 .idea/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ npm-debug.log
 coverage/
 .nyc_output/
 .idea/
-.DS_Store
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ const consumeConfig = {
   routingKey: 'some-routing-key'
 }
 
-const handleError = async (e) => logError(e)
+const handleError = async (e, message) => {
+  // message will be the raw AMQP message
+  logError(e, message)
+}
 
 const handleMessage = defaultParseAndHandleMessage(handleError, (data) => {
   // Content will be the *parsed* message content.
@@ -159,9 +162,9 @@ Create a Publisher function which can be used to publish messages to an exchange
 
 Base function for creating a MessageHandler to parse and handle consumed messages.  Most of the time, you'll want to use `defaultParseAndHandleMessage`.  Use this if you need to parse messages from a different format or handle Ack/Nack differently.
 
-### defaultParseAndHandleMessage : ((error:mixed &rArr; Promise&lt;mixed&gt;), MessageContentHandler&lt;JsonValue, mixed&gt;) &rArr; MessageHandler&lt;mixed&gt;
+### defaultParseAndHandleMessage : (MessageErrorHandler&lt;Error, mixed&gt; &rArr; MessageContentHandler&lt;JsonValue, mixed&gt;) &rArr; MessageHandler&lt;mixed&gt;
 
-Create a message handler that parses messages in JSON format, and automatically **acks** upon success or failed message handling. If an errors occurs during message parsing (e.g. invalid JSON) *or* message handling, the error will be passed to the error handler function (first param), *and the message will still be **acked***.  If you need different error handling ack/nack behavior, use `parseAndHandleMessage`.
+Create a message handler that parses messages in JSON format, and automatically **acks** upon success or failed message handling. If an errors occurs during message parsing (e.g. invalid JSON) *or* message handling, the error and raw AMQP message will be passed to the error handler function.  The message will still be **acked** after the error handler returns.  If you need different error handling ack/nack behavior, use `parseAndHandleMessage`.
 
 ### parseJsonMessage : string &rArr; MessageParser&lt;JsonValue&gt;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nowait/amqp",
   "description": "Describe your package",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "engineering@nowait.com",
   "license": "UNLICENSED",
   "main": "build/index.js",
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "babel -D -d build src",
     "test": "npm run check && npm run coverage",
-    "coverage": "babel-node node_modules/.bin/isparta cover node_modules/.bin/_mocha -- --reporter dot --recursive",
+    "coverage": "nyc mocha --reporter dot --recursive",
     "check": "flow && npm run lint",
     "lint": "jsinspect src && jsinspect --identifiers -t 35 test && eslint src test",
     "unit-test": "mocha",
@@ -25,25 +25,26 @@
     "build/"
   ],
   "devDependencies": {
-    "@nowait/eslint-config": "^1.0.3",
-    "assert": "^1.3.0",
-    "babel-cli": "^6.6.4",
-    "babel-core": "^6.6.4",
-    "babel-eslint": "^5.0.0",
-    "babel-plugin-syntax-flow": "^6.5.0",
-    "babel-plugin-transform-async-to-module-method": "^6.7.0",
-    "babel-plugin-transform-class-properties": "^6.6.0",
-    "babel-plugin-transform-flow-strip-types": "^6.6.4",
+    "@nowait/eslint-config": "^3.0.0",
+    "assert": "^1.4.1",
+    "babel-cli": "^6.24.0",
+    "babel-core": "^6.24.0",
+    "babel-eslint": "^7.2.0",
+    "babel-plugin-syntax-flow": "^6.18.0",
+    "babel-plugin-transform-async-to-module-method": "^6.22.0",
+    "babel-plugin-transform-class-properties": "^6.23.0",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-es2015-node5": "^1.1.2",
-    "babel-register": "^6.6.0",
-    "eslint": "~2.2.0",
-    "flow-bin": "^0.22.1",
+    "babel-register": "^6.24.0",
+    "eslint": "^3.18.0",
+    "flow-bin": "0.26.0",
     "isparta": "^4.0.0",
-    "jsinspect": "^0.8.0",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
+    "jsinspect": "^0.10.1",
+    "mocha": "^3.2.0",
+    "nyc": "^10.1.2",
+    "sinon": "^2.1.0"
   },
   "dependencies": {
-    "creed": "^1.0.1"
+    "creed": "^1.2.1"
   }
 }

--- a/src/amqp.js
+++ b/src/amqp.js
@@ -14,7 +14,7 @@ import type {
 // Given an AmqpConnection, returns a Channel, which can be
 // passed to consumeFrom or publishTo
 export const createChannel
-  : (connection:AmqpConnection|Promise<AmqpConnection>) => DuplexChannel =
+  : (connection: AmqpConnection | Promise<AmqpConnection>) => DuplexChannel =
   connection => async setup => {
     const c = await connection
     return c.createChannel().then(setup)
@@ -35,7 +35,7 @@ export function consumeFrom<C:ConsumeChannel> (channel: C): (config: ConsumeConf
 }
 
 // Create function which publishes messages to a queue
-export function publishTo<C:PublishChannel> (channel: C): (config: PublishConfig) => Publisher {
+export function publishTo<C: PublishChannel> (channel: C): (config: PublishConfig) => Publisher {
   return function (config) {
     const chp = channel(amqpChannel => assertExchange(config, amqpChannel))
 
@@ -62,7 +62,7 @@ export async function assertQueue<C:AmqpChannel> (config: ConsumeConfig, channel
 }
 
 // Helper to assert exchangeName
-export async function assertExchange<C:AmqpChannel> ({ exchangeName }: ExchangeConfig, channel: C): Promise<C> {
+export async function assertExchange<C: AmqpChannel> ({ exchangeName }: ExchangeConfig, channel: C): Promise<C> {
   await channel.assertExchange(exchangeName, 'topic', { autoDelete: false })
 
   return channel

--- a/src/defaultParseAndHandleMessage.js
+++ b/src/defaultParseAndHandleMessage.js
@@ -9,7 +9,7 @@ import parseJsonMessage from './parseJsonMessage'
 // Generally, errors won't be recovered from
 // So default behavior here is always to ack, thus dropping failed messages,
 // rather than nacking, which can lead to infinite retries if not managed carefully
-export default (handleError: (e:mixed) => Promise<mixed>, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
+export default (handleError: (e: mixed) => Promise<mixed>, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
   parseAndHandleMessage(parseJsonMessage('utf8'), ackOnError(handleError), ackOnComplete, handleMessage)
 
 const ackOnComplete: MessageResultHandler<mixed> = (ack, nack, message) =>

--- a/src/defaultParseAndHandleMessage.js
+++ b/src/defaultParseAndHandleMessage.js
@@ -9,7 +9,7 @@ import parseJsonMessage from './parseJsonMessage'
 // Generally, errors won't be recovered from
 // So default behavior here is always to ack, thus dropping failed messages,
 // rather than nacking, which can lead to infinite retries if not managed carefully
-export default (handleError: MessageErrorHandler, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
+export default (handleError: MessageErrorHandler<Error, mixed>, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
   parseAndHandleMessage(parseJsonMessage('utf8'), ackOnError(handleError), ackOnComplete, handleMessage)
 
 const ackOnComplete:

--- a/src/defaultParseAndHandleMessage.js
+++ b/src/defaultParseAndHandleMessage.js
@@ -1,7 +1,7 @@
 'use strict'
 // @flow
 
-import type { MessageHandler, MessageResultHandler, MessageContentHandler, JsonValue } from './index'
+import type { MessageHandler, MessageResultHandler, MessageContentHandler, MessageErrorHandler, JsonValue } from './index'
 
 import parseAndHandleMessage from './parseAndHandleMessage'
 import parseJsonMessage from './parseJsonMessage'
@@ -9,16 +9,20 @@ import parseJsonMessage from './parseJsonMessage'
 // Generally, errors won't be recovered from
 // So default behavior here is always to ack, thus dropping failed messages,
 // rather than nacking, which can lead to infinite retries if not managed carefully
-export default (handleError: (e: mixed) => Promise<mixed>, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
+export default (handleError: MessageErrorHandler, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler =>
   parseAndHandleMessage(parseJsonMessage('utf8'), ackOnError(handleError), ackOnComplete, handleMessage)
 
-const ackOnComplete: MessageResultHandler<mixed> = (ack, nack, message) =>
-  ack(message)
-
-const ackOnError = (handleError) => async (ack, nack, message, e) => {
-  try {
-    await handleError(e)
-  } finally {
+const ackOnComplete:
+  MessageResultHandler<mixed> =
+  (ack, nack, message) =>
     ack(message)
+
+const ackOnError:
+  (handleError: MessageErrorHandler) => MessageResultHandler<Error> =
+  (handleError) => async (ack, nack, message, e) => {
+    try {
+      await handleError(e, message)
+    } finally {
+      ack(message)
+    }
   }
-}

--- a/src/defaultParseAndHandleMessage.js
+++ b/src/defaultParseAndHandleMessage.js
@@ -18,7 +18,7 @@ const ackOnComplete:
     ack(message)
 
 const ackOnError:
-  (handleError: MessageErrorHandler) => MessageResultHandler<Error> =
+  (handleError: MessageErrorHandler<Error, mixed>) => MessageResultHandler<Error> =
   (handleError) => async (ack, nack, message, e) => {
     try {
       await handleError(e, message)

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -126,4 +126,6 @@ declare export function parseAndHandleMessage<C, R> (
   handleSuccess: MessageResultHandler<R>,
   handleMessage: MessageContentHandler<C, R>): MessageHandler<R>
 
-declare export function defaultParseAndHandleMessage(handleError: (e:mixed) => Promise<mixed>, handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler<mixed>
+declare export function defaultParseAndHandleMessage(
+  handleError: MessageErrorHandler<Error, mixed>,
+  handleMessage: MessageContentHandler<JsonValue, mixed>): MessageHandler<mixed>

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -61,7 +61,7 @@ export type MessageHandler<R> = (ack: Ack, nack: Nack, message: Message) => Prom
 export type MessageParser<T> = (msg: Message) => T
 export type MessageResultHandler<T> = (ack: Ack, nack: Nack, message: Message, result: T) => ?Promise<mixed>
 export type MessageContentHandler<C, R> = (content: C) => Promise<R>
-export type MessageErrorHandler = (e: Error, msg: Message) => Promise<mixed>
+export type MessageErrorHandler<E, R> = (e: E, msg: Message) => Promise<R>
 
 // Message publisher
 export type Publisher = (message: string) => Promise<boolean>

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -61,6 +61,7 @@ export type MessageHandler<R> = (ack: Ack, nack: Nack, message: Message) => Prom
 export type MessageParser<T> = (msg: Message) => T
 export type MessageResultHandler<T> = (ack: Ack, nack: Nack, message: Message, result: T) => ?Promise<mixed>
 export type MessageContentHandler<C, R> = (content: C) => Promise<R>
+export type MessageErrorHandler = (e: Error, msg: Message) => Promise<mixed>
 
 // Message publisher
 export type Publisher = (message: string) => Promise<boolean>

--- a/src/parseAndHandleMessage.js
+++ b/src/parseAndHandleMessage.js
@@ -8,7 +8,7 @@ import type {
 
 export default function parseAndHandleMessage<C, R> (
   parseMessage: MessageParser<C>,
-  handleFailure: MessageResultHandler<mixed>,
+  handleFailure: MessageResultHandler<Error>,
   handleSuccess: MessageResultHandler<R>,
   handleMessage: MessageContentHandler<C, R>): MessageHandler {
   return async (ack, nack, message) => {

--- a/src/parseAndHandleMessage.js
+++ b/src/parseAndHandleMessage.js
@@ -10,7 +10,7 @@ export default function parseAndHandleMessage<C, R> (
   parseMessage: MessageParser<C>,
   handleFailure: MessageResultHandler<Error>,
   handleSuccess: MessageResultHandler<R>,
-  handleMessage: MessageContentHandler<C, R>): MessageHandler {
+  handleMessage: MessageContentHandler<C, R>): MessageHandler<mixed> {
   return async (ack, nack, message) => {
     try {
       // Step 1: Triage message

--- a/test/defaultParseAndHandleMessage-test.js
+++ b/test/defaultParseAndHandleMessage-test.js
@@ -42,9 +42,9 @@ const verifyMessageHandling = (handleError, handleMessage, content) => {
 
 const verifyCounts = (expectedAckCount, expectedHandleCount, expectedHandleErrorCount) =>
   ({ ackCount, handleCount, handleErrorCount }) => {
-    assert.equal(expectedAckCount, ackCount)
-    assert.equal(expectedHandleCount, handleCount)
-    assert.equal(expectedHandleErrorCount, handleErrorCount)
+    assert.strictEqual(expectedAckCount, ackCount)
+    assert.strictEqual(expectedHandleCount, handleCount)
+    assert.strictEqual(expectedHandleErrorCount, handleErrorCount)
   }
 
 describe('defaultParseAndHandleMessage', () => {
@@ -53,13 +53,15 @@ describe('defaultParseAndHandleMessage', () => {
   it('should call handleError and ack if message handling fails', () => {
     const content = JSON.stringify({ foo: 'bar' })
 
+    const expectedError = new Error()
+
     const handleError = async (error) => {
-      assert(error instanceof Error)
+      assert.strictEqual(expectedError, error)
     }
 
     const handleMessage = async (data) => {
       assert.equal(content, JSON.stringify(data))
-      throw new Error()
+      throw expectedError
     }
 
     return verifyMessageHandling(handleError, handleMessage, content)
@@ -69,14 +71,16 @@ describe('defaultParseAndHandleMessage', () => {
   it('should ack if handleError fails', () => {
     const content = JSON.stringify({ foo: 'bar' })
 
+    const expectedError = new Error()
+
     const handleError = async (error) => {
-      assert(error instanceof Error)
+      assert.strictEqual(expectedError, error)
       throw new Error()
     }
 
     const handleMessage = async (data) => {
       assert.equal(content, JSON.stringify(data))
-      throw new Error()
+      throw expectedError
     }
 
     return verifyMessageHandling(handleError, handleMessage, content)

--- a/test/defaultParseAndHandleMessage-test.js
+++ b/test/defaultParseAndHandleMessage-test.js
@@ -5,154 +5,111 @@ import assert from 'assert'
 
 import defaultParseAndHandleMessage from '../src/defaultParseAndHandleMessage'
 
+const verifyMessageHandling = (handleError, handleMessage, content) => {
+  const message = { content }
+
+  let handleCount = 0
+  const _handleMessage = async (data) => {
+    handleCount++
+    return handleMessage(data)
+  }
+
+  let ackCount = 0
+  const ack = msg => {
+    ackCount++
+    assert.strictEqual(message, msg)
+  }
+
+  const nack = () => {
+    throw new Error('should not nack')
+  }
+
+  let handleErrorCount = 0
+  const _handleError = async (e) => {
+    handleErrorCount++
+    return handleError(e)
+  }
+
+  const parseAndHandle = defaultParseAndHandleMessage(_handleError, _handleMessage)
+
+  return parseAndHandle(ack, nack, message)
+    .then(
+      () => ({ ackCount, handleCount, handleErrorCount }),
+      () => Promise.reject({ ackCount, handleCount, handleErrorCount })
+    )
+}
+
+const verifyCounts = (expectedAckCount, expectedHandleCount, expectedHandleErrorCount) =>
+  ({ ackCount, handleCount, handleErrorCount }) => {
+    assert.equal(expectedAckCount, ackCount)
+    assert.equal(expectedHandleCount, handleCount)
+    assert.equal(expectedHandleErrorCount, handleErrorCount)
+  }
+
 describe('defaultParseAndHandleMessage', () => {
   // TODO: This *should nack*, but see comments in parseAndHandleMessage
   // for why it (temporarily) acks instead.
   it('should call handleError and ack if message handling fails', () => {
     const content = JSON.stringify({ foo: 'bar' })
-    const message = { content }
 
-    let handleCount = 0
+    const handleError = async (error) => {
+      assert(error instanceof Error)
+    }
+
     const handleMessage = async (data) => {
-      handleCount++
       assert.equal(content, JSON.stringify(data))
       throw new Error()
     }
 
-    let ackCount = 0
-    const ack = msg => {
-      ackCount++
-      assert.strictEqual(message, msg)
-    }
-
-    const nack = () => {
-      throw new Error('should not nack')
-    }
-
-    let handleErrorCount = 0
-    const handleError = async (error) => {
-      handleErrorCount++
-      assert(error instanceof Error)
-    }
-
-    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
-
-    return parseAndHandle(ack, nack, message)
-      .then(() => {
-        assert.equal(1, ackCount)
-        assert.equal(1, handleCount)
-        assert.equal(1, handleErrorCount)
-      })
+    return verifyMessageHandling(handleError, handleMessage, content)
+      .then(verifyCounts(1, 1, 1))
   })
 
   it('should ack if handleError fails', () => {
     const content = JSON.stringify({ foo: 'bar' })
-    const message = { content }
 
-    let handleCount = 0
-    const handleMessage = async (data) => {
-      handleCount++
-      assert.equal(content, JSON.stringify(data))
-      throw new Error()
-    }
-
-    let ackCount = 0
-    const ack = msg => {
-      ackCount++
-      assert.strictEqual(message, msg)
-    }
-
-    const nack = () => {
-      throw new Error('should not nack')
-    }
-
-    let handleErrorCount = 0
     const handleError = async (error) => {
-      handleErrorCount++
       assert(error instanceof Error)
       throw new Error()
     }
 
-    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
+    const handleMessage = async (data) => {
+      assert.equal(content, JSON.stringify(data))
+      throw new Error()
+    }
 
-    return parseAndHandle(ack, nack, message)
-      .then(assert.ifError, () => {
-        assert.equal(1, ackCount)
-        assert.equal(1, handleCount)
-        assert.equal(1, handleErrorCount)
-      })
+    return verifyMessageHandling(handleError, handleMessage, content)
+      .then(assert.ifError, verifyCounts(1, 1, 1))
   })
 
   it('should call handleError and ack if parsing fails', () => {
     const content = undefined
-    const message = { content }
 
-    let handleCount = 0
-    const handleMessage = async (data) => {
-      handleCount++
-      throw new Error()
-    }
-
-    let ackCount = 0
-    const ack = msg => {
-      ackCount++
-      assert.strictEqual(message, msg)
-    }
-
-    const nack = () => {
-      throw new Error('should not nack')
-    }
-
-    let handleErrorCount = 0
     const handleError = async (error) => {
-      handleErrorCount++
       assert(error instanceof Error)
     }
 
-    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
+    const handleMessage = async (data) => {
+      throw new Error()
+    }
 
-    return parseAndHandle(ack, nack, message)
-      .then(() => {
-        assert.equal(1, ackCount)
-        assert.equal(0, handleCount)
-        assert.equal(1, handleErrorCount)
-      })
+    return verifyMessageHandling(handleError, handleMessage, content)
+      .then(verifyCounts(1, 0, 1))
   })
 
   it('should ack if message handling succeeds', () => {
     const content = JSON.stringify({ foo: 'bar' })
-    const message = { content }
 
-    let handleCount = 0
+    const handleError = async (e) => {
+      throw e
+    }
+
     const handleMessage = async (data) => {
-      handleCount++
       assert.equal(content, JSON.stringify(data))
       return data
     }
 
-    let ackCount = 0
-    const ack = msg => {
-      ackCount++
-      assert.strictEqual(message, msg)
-    }
-
-    const nack = () => {
-      throw new Error('should not nack')
-    }
-
-    let handleErrorCount = 0
-    const handleError = async (e) => {
-      handleErrorCount++
-      throw e
-    }
-
-    const parseAndHandle = defaultParseAndHandleMessage(handleError, handleMessage)
-
-    return parseAndHandle(ack, nack, message)
-      .then(() => {
-        assert.equal(1, ackCount)
-        assert.equal(1, handleCount)
-        assert.equal(0, handleErrorCount)
-      })
+    return verifyMessageHandling(handleError, handleMessage, content)
+      .then(verifyCounts(1, 1, 0))
   })
 })

--- a/test/defaultParseAndHandleMessage-test.js
+++ b/test/defaultParseAndHandleMessage-test.js
@@ -25,9 +25,10 @@ const verifyMessageHandling = (handleError, handleMessage, content) => {
   }
 
   let handleErrorCount = 0
-  const _handleError = async (e) => {
+  const _handleError = async (e, msg) => {
     handleErrorCount++
-    return handleError(e)
+    assert.strictEqual(message, msg)
+    return handleError(e, msg)
   }
 
   const parseAndHandle = defaultParseAndHandleMessage(_handleError, _handleMessage)


### PR DESCRIPTION
The main purpose of this PR is to pass both the Error and AMQP Message to error handlers when using defaultParseAndHandleMessage.

### Motivation

This helps in logging more useful information about failed messages, since many times, the Error object contains only a generic description and stack trace.  For example, in many of our use cases, it would be useful to be able to log additional info, like the associated businessId or visitId, which probably only exists in the message payload.

### Other changes

This PR also:

* Updates all deps and devDeps, including refactoring to appease newer jsinspect strictness
* Switches from isparta to [nyc](https://github.com/istanbuljs/nyc).  [Isparta is no longer maintained](https://github.com/douglasduteil/isparta#isparta---), and nyc is the new official front end to istanbul code coverage.  The [license is ISC](https://github.com/istanbuljs/nyc/blob/master/LICENSE.txt), which is functionally equivalent to MIT.
* Tightens types on a few things, including error handlers.